### PR TITLE
Add loop_start, loop_stop, loop_forever methods, clean shutdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ client.connect(
     password='large4cats',
     key='AQ=='
 )
+
+# Start MQTT client loop until interrupted
+# If you want your script to perform other activities with the MQTT loop in another thread.
+# look at client.loop_start()
+client.loop_forever()
 ```
 
 ### Callback System

--- a/src/meshtastic_mqtt_json/client.py
+++ b/src/meshtastic_mqtt_json/client.py
@@ -52,6 +52,7 @@ class MeshtasticMQTT(object):
 	def __init__(self):
 		'''Initialize the Meshtastic MQTT client'''
 
+		self.client		  = None
 		self.broadcast_id = 4294967295 # Our channel ID
 		self.key          = None
 		self.names        = {}
@@ -113,11 +114,11 @@ class MeshtasticMQTT(object):
 		'''
 
 		# Initialize the MQTT client
-		client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id='', clean_session=True, userdata=None)
-		client.connect_timeout = 10
+		self.client = mqtt.Client(mqtt.CallbackAPIVersion.VERSION2, client_id='', clean_session=True, userdata=None)
+		self.client.connect_timeout = 10
 
 		# Set the username and password for the MQTT broker
-		client.username_pw_set(username=username, password=password)
+		self.client.username_pw_set(username=username, password=password)
 
 		# Set the encryption key
 		self.key = '1PG7OiApB1nwvP+rz05pAQ==' if key == 'AQ==' else key
@@ -132,23 +133,28 @@ class MeshtasticMQTT(object):
 			raise
 
 		# Set the MQTT callbacks
-		client.on_connect    = self.event_mqtt_connect
-		client.on_message    = self.event_mqtt_recv
-		client.on_disconnect = self.event_mqtt_disconnect
+		self.client.on_connect    = self.event_mqtt_connect
+		self.client.on_message    = self.event_mqtt_recv
+		self.client.on_disconnect = self.event_mqtt_disconnect
 
 		# Connect to the MQTT broker
 		try:
-			client.connect(broker, port, 60)
+			self.client.connect(broker, port, 60)
 		except Exception as e:
 			print(f'Error connecting to MQTT broker: {e}')
-			self.event_mqtt_disconnect(client, '', 1, None)
+			self.event_mqtt_disconnect(self.client, '', 1, None)
 
 		# Set the subscribe topic
 		self.subscribe_topic = f'{root}{channel}/#'
 
-		# Keep-alive loop
-		client.loop_forever()
+	def loop_forever(self):
+		self.client.loop_forever()
 
+	def loop_start(self):
+		self.client.loop_start()
+
+	def loop_stop(self):
+		self.client.loop_stop()
 
 	def decrypt_message_packet(self, mp):
 		'''

--- a/src/meshtastic_mqtt_json/client.py
+++ b/src/meshtastic_mqtt_json/client.py
@@ -52,12 +52,13 @@ class MeshtasticMQTT(object):
 	def __init__(self):
 		'''Initialize the Meshtastic MQTT client'''
 
-		self.client		  = None
-		self.broadcast_id = 4294967295 # Our channel ID
-		self.key          = None
-		self.names        = {}
-		self.filters      = None
-		self.callbacks    = {}  # Dictionary to store message type callbacks
+		self.client		   = None
+		self.broadcast_id  = 4294967295 # Our channel ID
+		self.key           = None
+		self.names         = {}
+		self.filters       = None
+		self.callbacks     = {}  # Dictionary to store message type callbacks
+		self.shutting_down = False
 
 
 	def register_callback(self, message_type: str, callback: callable):
@@ -146,6 +147,10 @@ class MeshtasticMQTT(object):
 
 		# Set the subscribe topic
 		self.subscribe_topic = f'{root}{channel}/#'
+
+	def disconnect(self):
+		self.shutting_down = True
+		self.client.disconnect()
 
 	def loop_forever(self):
 		self.client.loop_forever()
@@ -419,6 +424,8 @@ class MeshtasticMQTT(object):
 	def event_mqtt_disconnect(self, client, userdata, rc, packet_from_broker=None, properties=None, reason_code=None):
 		'''Callback for when the client disconnects from the server.'''
 		print(f'Disconnected with result code: {rc}')
+		if self.shutting_down:
+			return
 		while True:
 			print('Attempting to reconnect...')
 			try:


### PR DESCRIPTION
Also stop connect() from blocking, so it can be used in the same way as a paho_mqtt client.

This is addressing the issue I opened yesterday: https://github.com/acidvegas/meshtastic-mqtt-json/issues/1